### PR TITLE
Update Mach_and_BSD.md and iBoot-RE.md

### DIFF
--- a/wiki/Mach_and_BSD.md
+++ b/wiki/Mach_and_BSD.md
@@ -38,7 +38,7 @@ As stated before, Mach does not concern itself with higher level concepts, imple
 
 The core idea behind Mach its minimalism. Being a microkernel, Mach implements only the fundamental abstractions (described more in detail later).
 
-Another key point in the Mach philosophy is how the various subsystems communicate, i.e. via a message passing facility. Interaction between components is completely implemented via IPC in Mach. This means that objects cannot directly call/invoke themselves, rather a message is sent from one object to another, that message is queued until the receiver handles it.
+Another key point in the Mach philosophy is how the various subsystems communicate, i.e. via a message passing facility. Interaction between components is completely implemented via IPC (inter-process communication) in Mach. This means that objects cannot directly call/invoke themselves, rather a message is sent from one object to another, that message is queued until the receiver handles it.
 This may seem unconventional, and it is. But, since Mach is a microkernel, all of the subsystems are separated from one another, thus message passing is needed for communication.
 
 Summarizing, remember that Mach is just the pure foundation of XNU, and everything else is built upon it.

--- a/wiki/iBoot-RE.md
+++ b/wiki/iBoot-RE.md
@@ -7,7 +7,7 @@ We focus on 64 bit iBoot cause we should:)
 ### The Loading Address
 
 Bootloaders in general and iBoot in particular expect to run at a specific, predefined, addresses.
-Such an address called the __loading address__ of a bootloader.
+Such an address called the __loading address__ (reset vector) of a bootloader.
 When loading the bootloader into IDA you need to supply the loading address, so IDA will be able to resolve data and code references properly.
 
 Most Apple bootloaders start with a relocation code which compares the loading address with the current address and moves the bootloader if needed.


### PR DESCRIPTION
This PR clarifies what `IPC` means and fixes the correct `resect vector`'s name
