### PR TITLE
updated dead links

### DIFF
--- a/resources/papers/README.md
+++ b/resources/papers/README.md
@@ -15,36 +15,36 @@ Similarly, if you want to add documents, please submit a pull request with your 
 | *Document* | *Related Talk* | *Author* | *Year* |
 |----------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------|------------------------------------|--------|
 | [Attacking the XNU Kernel in El Capitan](https://www.blackhat.com/docs/eu-15/materials/eu-15-Todesco-Attacking-The-XNU-Kernal-In-El-Capitain.pdf) | [Attacking The XNU Kernel In El Capitan](https://www.youtube.com/watch?v=k550C0V79ts) | Luca Todesco | 2015 |
-| [OS X Kernel is As Strong as its Weakest Part](https://reverse.put.as/wp-content/uploads/2015/11/poc2015osxkernelisasstrongasitsweakestpartliangshuaitian.pdf) | N/A | Liang Chen, ShuaiTian Zhao | 2015 |
-| [Memory corruption is for wussies!](https://reverse.put.as/wp-content/uploads/2016/04/SyScan360_SG_2016_-_Memory_Corruption_is_for_wussies.pdf) | N/A | fG! | 2016 |
-| [Don’t Trust Your Eye: Apple Graphics is Compromised!](https://reverse.put.as/wp-content/uploads/2016/05/CanSecWest2016_Apple_Graphics_Compromised.pdf) | N/A | Liang Chen, Marco Grassi, Qidan He | 2016 |
-| [OS X El Capitan sinking the Ship](https://reverse.put.as/wp-content/uploads/2016/05/syscan360stefanesserosxelcapitansinkingtheship.pdf) | N/A | Stefan Esser | 2016 |
+| [OS X Kernel is As Strong as its Weakest Part](https://papers.put.as/papers/macosx/2015/poc2015osxkernelisasstrongasitsweakestpartliangshuaitian.pdf) | N/A | Liang Chen, ShuaiTian Zhao | 2015 |
+| [Memory corruption is for wussies!](https://papers.put.as/papers/macosx/2016/SyScan360_SG_2016_-_Memory_Corruption_is_for_wussies.pdf) | N/A | fG! | 2016 |
+| [Don’t Trust Your Eye: Apple Graphics is Compromised!](https://papers.put.as/papers/macosx/2016/CanSecWest2016_Apple_Graphics_Compromised.pdf) | N/A | Liang Chen, Marco Grassi, Qidan He | 2016 |
+| [OS X El Capitan sinking the Ship](https://papers.put.as/papers/macosx/2016/syscan360stefanesserosxelcapitansinkingtheship.pdf) | N/A | Stefan Esser | 2016 |
 |[XNU:A Security Evaluation](https://papers.put.as/papers/macosx/2012/XNU_-a-security-evaluation-Daan_Keuper_2012-12-14-xnu.pdf)| N/A | Daan_Keuper | 2012 |
 
 ## Technical
 | *Document* | *Related Talk* | *Author* | *Year* |
 |-----------------------------------------------------------------------------------------------------------|----------------|----------------|--------|
-| [DYLIB HIJACKING ON OS X](https://reverse.put.as/wp-content/uploads/2015/11/vb201503-dylib-hijacking.pdf) | N/A | Patrick Wardle | 2015 |
-| [Code Signing – Hashed Out](https://reverse.put.as/wp-content/uploads/2015/12/CodeSigning-RSA.pdf) | N/A | Jonathan Levin | 2015 |
+| [DYLIB HIJACKING ON OS X](https://papers.put.as/papers/macosx/2015/vb201503-dylib-hijacking.pdf) | N/A | Patrick Wardle | 2015 |
+| [Code Signing – Hashed Out](https://papers.put.as/papers/macosx/2015/CodeSigning-RSA.pdf) | N/A | Jonathan Levin | 2015 |
 | [The ARMs race to TrustZone](http://technologeeks.com/files/TZ.pdf) | N/A | Jonathan Levin | 2016 |
 # iOS
 
 ## Exploitation
 | *Document* | *Related Talk* | *Author* | *Year* |
 |-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------|--------|
-| [iOS Kernel Exploitation](https://reverse.put.as/wp-content/uploads/2011/06/BH_US_11_Esser_Exploiting_The_iOS_Kernel_Slides.pdf) | [BlackHat 2011 - iOS Kernel Exploitation](https://www.youtube.com/watch?v=fQHkA_s3d2o) | Stefan Esser | 2011 |
-| [iOS Kernel Exploitation -- IOKit Edition](https://reverse.put.as/wp-content/uploads/2011/06/SyScanTaipei2011_StefanEsser_iOS_Kernel_Exploitation_IOKit_Edition.pdf) | N/A | Stefan Esser | 2011 |
-| [iOS 5 An Exploitation Nightmare?](https://reverse.put.as/wp-content/uploads/2011/06/CSW2012_StefanEsser_iOS5_An_Exploitation_Nightmare_FINAL.pdf) | N/A | Stefan Esser | 2012 |
-| [iOS Kernel Heap Armageddon](https://reverse.put.as/wp-content/uploads/2011/06/SyScan2012_StefanEsser_iOS_Kernel_Heap_Armageddon.pdf) | N/A | Stefan Esser | 2012 |
+| [iOS Kernel Exploitation](https://papers.put.as/papers/ios/2011/BH_US_11_Esser_Exploiting_The_iOS_Kernel_Slides.pdf) | [BlackHat 2011 - iOS Kernel Exploitation](https://www.youtube.com/watch?v=fQHkA_s3d2o) | Stefan Esser | 2011 |
+| [iOS Kernel Exploitation -- IOKit Edition](https://papers.put.as/papers/ios/2011/SyScanTaipei2011_StefanEsser_iOS_Kernel_Exploitation_IOKit_Edition.pdf) | N/A | Stefan Esser | 2011 |
+| [iOS 5 An Exploitation Nightmare?](https://papers.put.as/papers/ios/2012/CSW2012_StefanEsser_iOS5_An_Exploitation_Nightmare_FINAL.pdf) | N/A | Stefan Esser | 2012 |
+| [iOS Kernel Heap Armageddon](https://papers.put.as/papers/ios/2012/SyScan2012_StefanEsser_iOS_Kernel_Heap_Armageddon.pdf) | N/A | Stefan Esser | 2012 |
 | [iOS 6 Kernel Security: A Hacker’s Guide](https://conference.hitb.org/hitbsecconf2012kul/materials/D1T2%20-%20Mark%20Dowd%20&%20Tarjei%20Mandt%20-%20iOS6%20Security.pdf) | [#HITB2012KUL D1T2 - Mark Dowd & Tarjei Mandt - iOS 6 Security](https://www.youtube.com/watch?v=O-WZinEoki4) | Mark Dowd, Tarjei Mandt | 2012 |
-| [Find Your Own iOS Kernel Bug](https://reverse.put.as/wp-content/uploads/2011/06/Xu-Hao-Xiabo-Chen-Find-Your-Own-iOS-Kernel-Bug.pdf) | N/A | Chen Xiaobo, Xu Hao | 2012 |
-| [Attacking the iOS Kernel: A Look at ‘evasi0n’](https://reverse.put.as/wp-content/uploads/2015/11/NISlecture201303.pdf) | N/A | Tarjei Mandt | 2013 |
-| [SWIPING THROUGH MODERN SECURITY FEATURES](https://reverse.put.as/wp-content/uploads/2011/06/D2T1-Pod2g-Planetbeing-Musclenerd-and-Pimskeks-aka-Evad3rs-Swiping-Through-Modern-Security-Features.pdf) | [#HITB2013AMS D2T1 Evad3rs - Swiping Through Modern Security Features](https://www.youtube.com/watch?v=brrIquvUR4M) | evad3rs | 2013 |
-| [Exploiting Unpatched iOS Vulnerabilities for Fun and Profit](https://reverse.put.as/wp-content/uploads/2015/11/iosjb_slide.pdf) | N/A | Yeongjin Jang, Tielei Wang, Byoungyoung Lee, Billy Lau | 2014 |
-| [iOS 6/7/8 Security - A Study in Fail](https://reverse.put.as/wp-content/uploads/2015/11/SyScan15_Stefan_Esser_-_iOS_678_Security_-_A_Study_in_Fail.pdf) | N/A | Stefan Esser | 2015 |
-| [OPTIMIZED FUZZING IOKIT IN iOS](https://reverse.put.as/wp-content/uploads/2015/11/us-15-Lei-Optimized-Fuzzing-IOKit-In-iOS.pdf) | [Optimized Fuzzing IOKit In iOS](https://www.youtube.com/watch?v=XDT9Cn8GjJU) | Lei Long | 2015 |
-| [Review and Exploit Neglected Attack Surface in iOS 8](https://reverse.put.as/wp-content/uploads/2015/11/us-15-Wang-Review-And-Exploit-Neglected-Attack-Surface-In-iOS-8.pdf) | N/A | Pangu Team | 2015 |
-| [Hacking from iOS 8 to iOS 9](https://reverse.put.as/wp-content/uploads/2015/11/POC2015_RUXCON2015.pdf) | N/A | Pangu Team | 2015 |
+| [Find Your Own iOS Kernel Bug](https://papers.put.as/papers/ios/2012/Xu-Hao-Xiabo-Chen-Find-Your-Own-iOS-Kernel-Bug.pdf) | N/A | Chen Xiaobo, Xu Hao | 2012 |
+| [Attacking the iOS Kernel: A Look at ‘evasi0n’](https://papers.put.as/papers/ios/2013/NISlecture201303.pdf) | N/A | Tarjei Mandt | 2013 |
+| [SWIPING THROUGH MODERN SECURITY FEATURES](https://papers.put.as/papers/ios/2013/D2T1-Pod2g-Planetbeing-Musclenerd-and-Pimskeks-aka-Evad3rs-Swiping-Through-Modern-Security-Features.pdf) | [#HITB2013AMS D2T1 Evad3rs - Swiping Through Modern Security Features](https://www.youtube.com/watch?v=brrIquvUR4M) | evad3rs | 2013 |
+| [Exploiting Unpatched iOS Vulnerabilities for Fun and Profit](https://papers.put.as/papers/ios/2014/iosjb_slide.pdf) | N/A | Yeongjin Jang, Tielei Wang, Byoungyoung Lee, Billy Lau | 2014 |
+| [iOS 6/7/8 Security - A Study in Fail](https://papers.put.as/papers/ios/2015/SyScan15_Stefan_Esser_-_iOS_678_Security_-_A_Study_in_Fail.pdf) | N/A | Stefan Esser | 2015 |
+| [OPTIMIZED FUZZING IOKIT IN iOS](https://papers.put.as/papers/ios/2015/us-15-Lei-Optimized-Fuzzing-IOKit-In-iOS-wp.pdf) | [Optimized Fuzzing IOKit In iOS](https://www.youtube.com/watch?v=XDT9Cn8GjJU) | Lei Long | 2015 |
+| [Review and Exploit Neglected Attack Surface in iOS 8](https://papers.put.as/papers/ios/2015/us-15-Wang-Review-And-Exploit-Neglected-Attack-Surface-In-iOS-8.pdf) | N/A | Pangu Team | 2015 |
+| [Hacking from iOS 8 to iOS 9](https://papers.put.as/papers/ios/2015/POC2015_RUXCON2015.pdf) | N/A | Pangu Team | 2015 |
 | [Dig Into The Attack Surface Of PDF And Gain 100 CVEs In 1 Year](https://www.blackhat.com/docs/asia-17/materials/asia-17-Liu-Dig-Into-The-Attack-Surface-Of-PDF-And-Gain-100-CVEs-In-1-Year.pdf)| N/A | Tencent XuanWu Lab | 2017 |
 
 


### PR DESCRIPTION
reverse.put.as moved all papers to papers.put.as, rendering all the old links dead. 
here's the readme with all the updated links on papers.put.as